### PR TITLE
Support embedded mode and constrain chat width for iframe integration

### DIFF
--- a/src/chat/App.jsx
+++ b/src/chat/App.jsx
@@ -1,12 +1,13 @@
 import "./App.css";
 import Sidebar from "./components/Sidebar/Sidebar";
 import ChatWindow from "./components/ChatWindow/ChatWindow";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import "./index.css";
 import "./i18n.js";
 
 function AppChat() {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const isEmbedded = useMemo(() => window.self !== window.top, []);
 
   // Функция для переключения состояния боковой панели
   const toggleSidebar = () => {
@@ -15,7 +16,11 @@ function AppChat() {
 
   return (
     <>
-      <div className="flex wrapper relative items-stretch">
+      <div
+        className={`flex wrapper relative items-stretch ${
+          isEmbedded ? "wrapper--embedded" : ""
+        }`}
+      >
         {/* Передаём состояние и функцию в Sidebar */}
         <Sidebar isSidebarOpen={isSidebarOpen} toggleSidebar={toggleSidebar} />
         <ChatWindow

--- a/src/chat/index.css
+++ b/src/chat/index.css
@@ -30,6 +30,37 @@ input:focus {
   height: 100vh;
 }
 
+html,
+body,
+#root {
+  width: 100%;
+  min-height: 100%;
+}
+
+.wrapper--embedded {
+  width: clamp(560px, 50vw, 960px);
+  max-width: 100vw;
+  min-width: 320px;
+  margin-left: 0;
+}
+
+.wrapper--embedded .chat-window {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.wrapper--embedded .message-list,
+.wrapper--embedded .message-list-wrap,
+.wrapper--embedded .bottom__wrapper,
+.wrapper--embedded .person__wrapper {
+  max-width: 100%;
+}
+
+.wrapper--embedded .chat-window-start .bottom__wrapper {
+  width: 100%;
+}
+
+
 .message-list-wrap {
   min-height: calc(100vh - 158px) !important;
   max-height: calc(100vh - 158px) !important;
@@ -116,5 +147,13 @@ input:focus {
   }
   .message-list {
     min-height: calc(100vh - 190px) !important;
+  }
+}
+
+
+@media (max-width: 700px) {
+  .wrapper--embedded {
+    width: 100vw;
+    max-width: none;
   }
 }


### PR DESCRIPTION
### Motivation
- Make the chat UI render compactly when it's embedded via an `iframe` so the visible bot area visually targets roughly half of the user's screen without changing existing functionality.
- Provide a safe client-side approach that works from inside the chat app when there is no control over the host page or iframe container.

### Description
- Detect embed mode with `window.self !== window.top` and add the `wrapper--embedded` modifier class in `src/chat/App.jsx` to switch styles when the app runs inside an `iframe`.
- Add CSS rules in `src/chat/index.css` to constrain the embedded wrapper using `width: clamp(560px, 50vw, 960px)` and adjust internal blocks (`.chat-window`, `.message-list`, `.bottom__wrapper`, `.person__wrapper`) so content respects the new container width.
- Keep mobile behavior unchanged by allowing the embedded wrapper to be full-width under `700px` and avoid touching any chat logic or features.
- Note that guaranteeing an exact half-screen width requires modifying the host page or the `iframe` element itself, which is outside the app's control. This change optimizes the chat contents for a half-screen visual target from inside the `iframe`.

### Testing
- Ran `npm run build` and the production build completed successfully.
- No automated visual/browser screenshot tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb4dc2fa7c8328bf394ea617681f89)