### PR TITLE
Remove embedded iframe layout overrides

### DIFF
--- a/src/chat/App.jsx
+++ b/src/chat/App.jsx
@@ -1,13 +1,12 @@
 import "./App.css";
 import Sidebar from "./components/Sidebar/Sidebar";
 import ChatWindow from "./components/ChatWindow/ChatWindow";
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import "./index.css";
 import "./i18n.js";
 
 function AppChat() {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
-  const isEmbedded = useMemo(() => window.self !== window.top, []);
 
   // Функция для переключения состояния боковой панели
   const toggleSidebar = () => {
@@ -16,11 +15,7 @@ function AppChat() {
 
   return (
     <>
-      <div
-        className={`flex wrapper relative items-stretch ${
-          isEmbedded ? "wrapper--embedded" : ""
-        }`}
-      >
+      <div className="flex wrapper relative items-stretch">
         {/* Передаём состояние и функцию в Sidebar */}
         <Sidebar isSidebarOpen={isSidebarOpen} toggleSidebar={toggleSidebar} />
         <ChatWindow

--- a/src/chat/index.css
+++ b/src/chat/index.css
@@ -37,30 +37,6 @@ body,
   min-height: 100%;
 }
 
-.wrapper--embedded {
-  width: clamp(560px, 50vw, 960px);
-  max-width: 100vw;
-  min-width: 320px;
-  margin-left: 0;
-}
-
-.wrapper--embedded .chat-window {
-  flex: 1 1 auto;
-  min-width: 0;
-}
-
-.wrapper--embedded .message-list,
-.wrapper--embedded .message-list-wrap,
-.wrapper--embedded .bottom__wrapper,
-.wrapper--embedded .person__wrapper {
-  max-width: 100%;
-}
-
-.wrapper--embedded .chat-window-start .bottom__wrapper {
-  width: 100%;
-}
-
-
 .message-list-wrap {
   min-height: calc(100vh - 158px) !important;
   max-height: calc(100vh - 158px) !important;
@@ -147,13 +123,5 @@ body,
   }
   .message-list {
     min-height: calc(100vh - 190px) !important;
-  }
-}
-
-
-@media (max-width: 700px) {
-  .wrapper--embedded {
-    width: 100vw;
-    max-width: none;
   }
 }


### PR DESCRIPTION
### Motivation
- Remove experimental iframe/embed-specific layout and styles that conflicted with the app's standard responsive layout.
- Keep the original adaptive browser layout untouched while cleaning up the extra embed-specific code that was added earlier.

### Description
- Removed iframe/embed detection and `isEmbedded` usage from `src/chat/App.jsx` so the wrapper no longer conditionally adds `wrapper--embedded`.
- Deleted all `.wrapper--embedded` CSS rules and the related mobile media-query from `src/chat/index.css` to avoid embed-specific overrides.
- Preserved existing base styles and responsive breakpoints for `.wrapper`, `.message-list*`, and `.sidebar` so regular browser behavior is unchanged.
- Changes applied to `src/chat/App.jsx` and `src/chat/index.css` only.

### Testing
- Ran `npm run build` and the production build completed successfully (no build errors).
- Ran `npm run lint` which failed, but failures are pre-existing lint issues unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69caf70080308328985ef5977bd43cb0)