### PR TITLE
Improve chat watermark SVG: support two-line text, centered badge, and refined styling

### DIFF
--- a/src/chat/components/ChatWindow/ChatWindow.jsx
+++ b/src/chat/components/ChatWindow/ChatWindow.jsx
@@ -39,11 +39,18 @@ export default function ChatWindow({ isSidebarOpen, toggleSidebar }) {
   const watermarkText = t("chat.watermarkText");
 
   const watermarkBackground = useMemo(() => {
+    const [firstLine = "", ...restLines] = watermarkText.split(" ");
+    const secondLine = restLines.join(" ");
+
     const svg = `
       <svg xmlns="http://www.w3.org/2000/svg" width="220" height="140" viewBox="0 0 220 140">
-        <g transform="translate(28 60) rotate(-35)">
-          <rect x="0" y="-16" width="14" height="14" fill="none" stroke="#6d7f98" stroke-width="1" opacity="0.5" />
-          <text x="20" y="-2" font-family="Arial, sans-serif" font-size="14" fill="#6d7f98" opacity="0.4">${watermarkText}</text>
+        <g transform="translate(56 76) rotate(-35)">
+          <rect x="42" y="-28" width="12" height="12" fill="none" stroke="#6d7f98" stroke-width="1" opacity="0.45" transform="rotate(45 48 -22)" />
+          <text x="48" y="-19" text-anchor="middle" font-family="Arial, sans-serif" font-size="8" font-weight="700" fill="#6d7f98" opacity="0.45">!</text>
+          <text x="48" y="-2" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#6d7f98" opacity="0.4">
+            <tspan x="48" dy="0">${firstLine}</tspan>
+            ${secondLine ? `<tspan x="48" dy="14">${secondLine}</tspan>` : ""}
+          </text>
         </g>
       </svg>
     `;


### PR DESCRIPTION
### Motivation
- Increase watermark readability and visual clarity by allowing two-line text, a centered badge icon, and refined positioning and styling for better appearance across locales.

### Description
- Split `watermarkText` into `firstLine` and `secondLine` and render them as separate `<tspan>` elements inside the SVG so the watermark can appear on two lines when needed.
- Update the SVG transform and element coordinates, add a rotated rectangle decoration, and add a centered `!` icon with adjusted font sizes, weight, and opacity.
- Return the SVG as an encoded data URL inside a `useMemo` hook that depends on `watermarkText`.

### Testing
- Ran `yarn build` to validate the app build and SVG generation, and the build completed successfully.
- Ran frontend unit tests with `yarn test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfab740c54832897a1fefcb76b32ad)