### PR TITLE
Fix mobile voice input getting stuck after first recording

### DIFF
--- a/src/chat/components/ChatWindow/MessageInput/MessageInput.jsx
+++ b/src/chat/components/ChatWindow/MessageInput/MessageInput.jsx
@@ -196,10 +196,6 @@ export default function MessageInput() {
             handleMicClick();
             setHideMicTooltip(true);
           }}
-          onTouchEnd={(e) => {
-            handleMicClick();
-            setHideMicTooltip(true);
-          }}
           disabled={isUploading}
         >
           {isUploading ? (


### PR DESCRIPTION
### Motivation
- On mobile browsers a tap can trigger both touch and click events causing the microphone button to toggle twice and leave voice input stuck loading on subsequent attempts.

### Description
- Removed the `onTouchEnd` handler from the mic button in `src/chat/components/ChatWindow/MessageInput/MessageInput.jsx` so the mic toggle uses only the `onClick` path.

### Testing
- Successfully built the production bundle with `npm run build` (Vite build completed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3b31bd7b88328a0f0fe0f65bd29a8)